### PR TITLE
add FormatException handling when no stock or facility selection is made

### DIFF
--- a/src/Actions/ChooseGrazingField.cs
+++ b/src/Actions/ChooseGrazingField.cs
@@ -24,14 +24,9 @@ namespace Trestlebridge.Actions
 
             Console.Write("> ");
             int choice = Int32.Parse(Console.ReadLine());
-            try
-            {
-                farm.GrazingFields[choice - 1].AddResource(animal);
-            }
-            catch
-            {
-                Console.WriteLine("Please press return and choose a different facility");
-            }
+
+            farm.GrazingFields[choice - 1].AddResource(animal);
+
 
             /*
                 Couldn't get this to work. Can you?

--- a/src/Actions/CreateFacility.cs
+++ b/src/Actions/CreateFacility.cs
@@ -20,24 +20,32 @@ namespace Trestlebridge.Actions
             Console.Write("> ");
             string input = Console.ReadLine();
 
-            switch (Int32.Parse(input))
+            try
             {
-                case 1:
-                    farm.AddGrazingField(new GrazingField());
-                    break;
-                case 2:
-                    farm.AddGrazingField(new GrazingField());
-                    break;
-                case 3:
-                    farm.AddDuckHouse(new DuckHouse());
-                    break;
-                case 4:
-                    farm.AddChickenHouse(new ChickenHouse());
-                    break;
+                switch (Int32.Parse(input))
+                {
+                    case 1:
+                        farm.AddGrazingField(new GrazingField());
+                        break;
+                    case 2:
+                        farm.AddGrazingField(new GrazingField());
+                        break;
+                    case 3:
+                        farm.AddDuckHouse(new DuckHouse());
+                        break;
+                    case 4:
+                        farm.AddChickenHouse(new ChickenHouse());
+                        break;
 
 
-                default:
-                    break;
+                    default:
+                        break;
+                }
+            }
+            catch (FormatException)
+            {
+                Console.WriteLine("Please select an available facility option");
+                CreateFacility.CollectInput(farm);
             }
         }
     }

--- a/src/Actions/PurchaseStock.cs
+++ b/src/Actions/PurchaseStock.cs
@@ -4,13 +4,16 @@ using Trestlebridge.Models;
 using Trestlebridge.Models.Animals;
 using Trestlebridge.Models.Facilities;
 
-namespace Trestlebridge.Actions {
-    public class PurchaseStock {
-        public static void CollectInput (Farm farm) {
-            Console.WriteLine ("1. Cow");
-            Console.WriteLine ("2. Ostrich");
-            Console.WriteLine ("3. Chicken");
-            Console.WriteLine ("4. Duck");
+namespace Trestlebridge.Actions
+{
+    public class PurchaseStock
+    {
+        public static void CollectInput(Farm farm)
+        {
+            Console.WriteLine("1. Cow");
+            Console.WriteLine("2. Ostrich");
+            Console.WriteLine("3. Chicken");
+            Console.WriteLine("4. Duck");
 
             Console.WriteLine();
             Console.WriteLine("What are you buying today?");
@@ -18,16 +21,24 @@ namespace Trestlebridge.Actions {
             Console.Write("> ");
             string choice = Console.ReadLine();
 
-            switch (Int32.Parse(choice))
+            try
             {
-                case 1:
-                    ChooseGrazingField.CollectInput(farm, new Cow());
-                    break;
-                case 2:
-                    ChooseGrazingField.CollectInput(farm, new Ostrich());
-                    break;
-                default:
-                    break;
+                switch (Int32.Parse(choice))
+                {
+                    case 1:
+                        ChooseGrazingField.CollectInput(farm, new Cow());
+                        break;
+                    case 2:
+                        ChooseGrazingField.CollectInput(farm, new Ostrich());
+                        break;
+                    default:
+                        break;
+                }
+            }
+            catch (FormatException)
+            {
+                Console.WriteLine("Please select an available stock option");
+                PurchaseStock.CollectInput(farm);
             }
         }
     }


### PR DESCRIPTION
Format Exception handling when no Stock or Facility is selected

Fixes
Keeps app from crashing

# Testing Instructions
Create a facility
Hit enter without making a selection to see new prompt (no crash)
Select facility
Purchase stock
Hit enter without making a selection to see new prompt (no crash)
Make stock selection
View farm status



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works