### PR TITLE
add Console.Clear to keep multiple stock and facility lists from pili…

### DIFF
--- a/src/Actions/CreateFacility.cs
+++ b/src/Actions/CreateFacility.cs
@@ -44,6 +44,7 @@ namespace Trestlebridge.Actions
             }
             catch (FormatException)
             {
+                Console.Clear();
                 Console.WriteLine("Please select an available facility option");
                 CreateFacility.CollectInput(farm);
             }

--- a/src/Actions/CreateFacility.cs
+++ b/src/Actions/CreateFacility.cs
@@ -45,6 +45,14 @@ namespace Trestlebridge.Actions
             catch (FormatException)
             {
                 Console.Clear();
+                Console.WriteLine();
+                Console.WriteLine(@"
+                +-++-++-++-++-++-++-++-++-++-++-++-++-+
+                |T||r||e||s||t||l||e||b||r||i||d||g||e|
+                +-++-++-++-++-++-++-++-++-++-++-++-++-+
+                            |F||a||r||m||s|
+                            +-++-++-++-++-+");
+                Console.WriteLine();
                 Console.WriteLine("Please select an available facility option");
                 CreateFacility.CollectInput(farm);
             }

--- a/src/Actions/PurchaseStock.cs
+++ b/src/Actions/PurchaseStock.cs
@@ -41,6 +41,14 @@ namespace Trestlebridge.Actions
             catch (FormatException)
             {
                 Console.Clear();
+                Console.WriteLine();
+                Console.WriteLine(@"
+        +-++-++-++-++-++-++-++-++-++-++-++-++-+
+        |T||r||e||s||t||l||e||b||r||i||d||g||e|
+        +-++-++-++-++-++-++-++-++-++-++-++-++-+
+                    |F||a||r||m||s|
+                    +-++-++-++-++-+");
+                Console.WriteLine();
                 Console.WriteLine("Please select an available stock option");
                 PurchaseStock.CollectInput(farm);
             }

--- a/src/Actions/PurchaseStock.cs
+++ b/src/Actions/PurchaseStock.cs
@@ -40,6 +40,7 @@ namespace Trestlebridge.Actions
             }
             catch (FormatException)
             {
+                Console.Clear();
                 Console.WriteLine("Please select an available stock option");
                 PurchaseStock.CollectInput(farm);
             }


### PR DESCRIPTION
add Console.Clear to catch in CreateFacility.cs and PurchaseStock.cs

Fixes
Keeps Stock and Facility Lists from piling up