### PR TITLE
Adding animal count to grazing fields, duck houses, chicken houses

### DIFF
--- a/src/Actions/ChooseChickenHouse.cs
+++ b/src/Actions/ChooseChickenHouse.cs
@@ -14,7 +14,7 @@ namespace Trestlebridge.Actions
 
             for (int i = 0; i < farm.ChickenHouses.Count; i++)
             {
-                Console.WriteLine($"{i + 1}. Chicken House {farm.ChickenHouses[i].id}");
+                Console.WriteLine($"{i + 1}. Chicken House {farm.ChickenHouses[i].id} has {farm.ChickenHouses[i].AnimalCount} animals");
             }
 
             Console.WriteLine();

--- a/src/Actions/ChooseDuckHouse.cs
+++ b/src/Actions/ChooseDuckHouse.cs
@@ -14,7 +14,7 @@ namespace Trestlebridge.Actions
 
             for (int i = 0; i < farm.DuckHouses.Count; i++)
             {
-                Console.WriteLine($"{i + 1}. Duck House {farm.DuckHouses[i].id}");
+                Console.WriteLine($"{i + 1}. Duck House {farm.DuckHouses[i].id} has {farm.DuckHouses[i].AnimalCount} animals");
             }
 
             Console.WriteLine();

--- a/src/Actions/ChooseGrazingField.cs
+++ b/src/Actions/ChooseGrazingField.cs
@@ -14,7 +14,7 @@ namespace Trestlebridge.Actions
 
             for (int i = 0; i < farm.GrazingFields.Count; i++)
             {
-                Console.WriteLine($"{i + 1}. Grazing Field {farm.GrazingFields[i].id}");
+                Console.WriteLine($"{i + 1}. Grazing Field {farm.GrazingFields[i].id} has {farm.GrazingFields[i].AnimalCount} animals");
             }
 
             Console.WriteLine();

--- a/src/Models/Facilities/ChickenHouse.cs
+++ b/src/Models/Facilities/ChickenHouse.cs
@@ -8,6 +8,13 @@ namespace Trestlebridge.Models.Facilities
 {
     public class ChickenHouse : IFacility<IHousable>
     {
+        public int AnimalCount
+        {
+            get
+            {
+                return _animals.Count;
+            }
+        }
         private int _capacity = 50;
         private Guid _id = Guid.NewGuid();
 

--- a/src/Models/Facilities/DuckHouse.cs
+++ b/src/Models/Facilities/DuckHouse.cs
@@ -8,6 +8,13 @@ namespace Trestlebridge.Models.Facilities
 {
     public class DuckHouse : IFacility<IHousable>
     {
+        public int AnimalCount
+        {
+            get
+            {
+                return _animals.Count;
+            }
+        }
         private int _capacity = 50;
         private Guid _id = Guid.NewGuid();
 

--- a/src/Models/Facilities/GrazingField.cs
+++ b/src/Models/Facilities/GrazingField.cs
@@ -8,6 +8,13 @@ namespace Trestlebridge.Models.Facilities
 {
     public class GrazingField : IFacility<IGrazing>
     {
+        public int AnimalCount
+        {
+            get
+            {
+                return _animals.Count;
+            }
+        }
         private int _capacity = 50;
         private Guid _id = Guid.NewGuid();
 


### PR DESCRIPTION
# Description

User should now be able to see how many animals are in their assigned field/house
1. Create grazing field
1. Add cow or ostrich
1. Add another, and it should display the current capacity of the chosen field
1. Same for chickens to chicken houses, and ducks to duck houses

Fixes # 8

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing Instructions

1. git checkout master
1. git fetch --all 
1. git checkout ```rm-ticket8```
1. code . 
1. test functionality



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works