### PR TITLE
add display types of plants in fields

### DIFF
--- a/src/Actions/ChooseNaturalField.cs
+++ b/src/Actions/ChooseNaturalField.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trestlebridge.Interfaces;
 using Trestlebridge.Models;
+using Trestlebridge.Models.Facilities;
 using Trestlebridge.Models.Animals;
 
 namespace Trestlebridge.Actions
@@ -11,30 +12,61 @@ namespace Trestlebridge.Actions
     {
         public static void CollectInput(Farm farm, ICompost plant)
         {
+            var fullNaturalFields = new List<int>();
+            // Make a list of available fields
             Console.Clear();
-
             for (int i = 0; i < farm.NaturalFields.Count; i++)
             {
-                Console.WriteLine($"{i + 1}. Natural Field {farm.NaturalFields[i].id} has {farm.NaturalFields[i].PlantCount} plants");
+                if (farm.NaturalFields[i].PlantCount < farm.NaturalFields[i].Capacity)
+                {
+                    // Calculate Plant Count By Type
+                    var typeList = (from p in farm.NaturalFields[i].PlantsList
+                                    group p by p.Type into g
+                                    let count = g.Count()
+                                    select new { Value = g.Key, Count = count });
+
+                    // Print Message
+                    Console.WriteLine($"{i + 1}. Natural Field {farm.NaturalFields[i].id} has {farm.NaturalFields[i].PlantCount} plant rows");
+                    if (farm.NaturalFields[i].PlantCount > 0)
+                    {
+                        foreach (var type in typeList)
+                        {
+                            Console.WriteLine($"     {type.Value}: {type.Count}");
+                        }
+                    }
+                }
+                else
+                {
+                    fullNaturalFields.Add(i);
+                };
             }
-
-            Console.WriteLine();
-
-            // How can I output the type of seeds chosen here?
-            Console.WriteLine($"Place the seeds where?");
-
-            Console.Write("> ");
-            int choice = Int32.Parse(Console.ReadLine());
-
-            farm.NaturalFields[choice - 1].AddResource(plant);
-
-
-            /*
-                Couldn't get this to work. Can you?
-                Stretch goal. Only if the app is fully functional.
-             */
-            // farm.PurchaseResource<IGrazing>(animal, choice);
-
+            if (fullNaturalFields.Count == farm.NaturalFields.Count)
+            {
+                Console.WriteLine("Please create a new facility");
+                CreateFacility.CollectInput(farm);
+            }
+            else
+            {
+                Console.WriteLine($"Plant the seeds where?");
+                Console.Write("> ");
+                int choice = Int32.Parse(Console.ReadLine());
+                if (farm.NaturalFields[choice - 1].PlantCount < farm.NaturalFields[choice - 1].Capacity)
+                {
+                    farm.NaturalFields[choice - 1].AddResource(plant);
+                }
+                else
+                {
+                    Console.WriteLine("Please select an available facility option");
+                    CreateFacility.CollectInput(farm);
+                }
+                Console.WriteLine();
+                // How can I output the type of seeds chosen here?
+                /*
+                    Couldn't get this to work. Can you?
+                    Stretch goal. Only if the app is fully functional.
+                 */
+                // farm.PurchaseResource<IGrazing>(animal, choice);
+            }
         }
     }
 }

--- a/src/Actions/ChoosePlowedField.cs
+++ b/src/Actions/ChoosePlowedField.cs
@@ -10,7 +10,7 @@ namespace Trestlebridge.Actions
 {
     public class ChoosePlowedField
     {
-        public static void CollectInput(Farm farm, ISeedProducing animal)
+        public static void CollectInput(Farm farm, ISeedProducing plant)
         {
             var fullPlowedFields = new List<int>();
             // Make a list of available fields
@@ -19,16 +19,16 @@ namespace Trestlebridge.Actions
             {
                 if (farm.PlowingFields[i].PlantCount < farm.PlowingFields[i].Capacity)
                 {
-                    // Calculate Animal Count By Type
-                    var typesList = (from creature in farm.PlowingFields[i].PlantsList
-                                     group creature by creature.Type into g
+                    // Calculate Plant Count By Type
+                    var typesList = (from p in farm.PlowingFields[i].PlantsList
+                                     group p by p.Type into g
                                      let count = g.Count()
                                      select new { Value = g.Key, Count = count });
 
 
 
                     // Print Message
-                    Console.WriteLine($"{i + 1}. Plowing Field {farm.PlowingFields[i].id} has {farm.PlowingFields[i].PlantCount} Plants");
+                    Console.WriteLine($"{i + 1}. Plowing Field {farm.PlowingFields[i].id} has {farm.PlowingFields[i].PlantCount} plant rows");
                     if (farm.PlowingFields[i].PlantCount > 0)
                     {
                         foreach (var type in typesList)
@@ -40,8 +40,6 @@ namespace Trestlebridge.Actions
                 else
                 {
                     fullPlowedFields.Add(i);
-                    // Console.WriteLine("Please select an available facility option");
-                    // CreateFacility.CollectInput(farm);
                 };
             }
             if (fullPlowedFields.Count == farm.PlowingFields.Count)
@@ -51,16 +49,15 @@ namespace Trestlebridge.Actions
             }
             else
             {
-                Console.WriteLine($"Place the animal where?");
+                Console.WriteLine($"Place the seeds where?");
                 Console.Write("> ");
                 int choice = Int32.Parse(Console.ReadLine());
                 if (farm.PlowingFields[choice - 1].PlantCount < farm.PlowingFields[choice - 1].Capacity)
                 {
-                    farm.PlowingFields[choice - 1].AddResource(animal);
+                    farm.PlowingFields[choice - 1].AddResource(plant);
                 }
                 else
                 {
-                    // Console.WriteLine("This field is full ");
                     Console.WriteLine("Please select an available facility option");
                     CreateFacility.CollectInput(farm);
                 }

--- a/src/Interfaces/ICompost.cs
+++ b/src/Interfaces/ICompost.cs
@@ -4,5 +4,6 @@ namespace Trestlebridge.Interfaces
     {
 
         double Compost();
+        string Type { get; }
     }
 }

--- a/src/Models/Facilities/NaturalField.cs
+++ b/src/Models/Facilities/NaturalField.cs
@@ -28,6 +28,13 @@ namespace Trestlebridge.Models.Facilities
         private List<ICompost> _plants = new List<ICompost>()
         {
         };
+        public List<ICompost> PlantsList
+        {
+            get
+            {
+                return _plants;
+            }
+        }
         public double PlantCount
         {
             get
@@ -42,19 +49,19 @@ namespace Trestlebridge.Models.Facilities
         //         return _capacity;
         //     }
         // }
-        public void AddResource(ICompost animal)
+        public void AddResource(ICompost plant)
         {
             // Add animal to List or return user to facility list in terminal
             try
             {
-                _plants.Add(animal);
+                _plants.Add(plant);
             }
             catch
             {
                 Console.WriteLine("Press return to choose a different facility");
             }
         }
-        public void AddResource(List<ICompost> animals)
+        public void AddResource(List<ICompost> plants)
         {
             // TODO: implement this...
             // throw new NotImplementedException();

--- a/src/Models/Facilities/PlowingField.cs
+++ b/src/Models/Facilities/PlowingField.cs
@@ -7,7 +7,7 @@ namespace Trestlebridge.Models.Facilities
 {
     public class PlowingField : IFacility<ISeedProducing>
     {
-        public double Capacity { get; } = 3;
+        public double Capacity { get; } = 2;
         // public int AnimalCount
         // {
         //     get


### PR DESCRIPTION
# Description
updated ChooseNaturalField.cs and ChoosePlowedField.cs to share similar logic and functionality to ChooseGrazingField.cs

Fixes # (issue)
Displays count of each individual type in the field
checks to see if field is at capacity, if so prompts user to create a new facility

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing Instructions
Create Plowed and Natural Fields (capacity is currently 2 for each)
Add Plants to each field
Add a 3rd type of plant for each field - should prompt user to create a new facility


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works